### PR TITLE
Baseline baseimage for templates on 0.0.1

### DIFF
--- a/setup/src/cpp/common/Dockerfile
+++ b/setup/src/cpp/common/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:latest
+FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.0.1
 
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE
 ENV REINSTALL_CMAKE_VERSION_FROM_SOURCE="${REINSTALL_CMAKE_VERSION_FROM_SOURCE:-none}"

--- a/setup/src/python/common/Dockerfile
+++ b/setup/src/python/common/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/python:latest
+FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.0.1
 
 # Force dapr to use localhost traffic
 ENV DAPR_HOST_IP="127.0.0.1"


### PR DESCRIPTION
Stabilization of templates by using a baselined version of DevContainer image version 0.0.1