### PR TITLE
move all settings to devcontainer.json to have control via cli

### DIFF
--- a/setup/src/cpp/common/devcontainer.json
+++ b/setup/src/cpp/common/devcontainer.json
@@ -23,6 +23,9 @@
 					"editor.defaultFormatter": "xaver.clang-format"
 				},
 				"editor.formatOnSave": true,
+				"json.format.keepLines": true,
+				"cmake.configureOnEdit": false,
+				"cmake.configureOnOpen": false,
 				"clang-tidy.fixOnSave": true,
 				"clang-tidy.lintOnSave": true,
 				"clang-tidy.blacklist": [
@@ -34,26 +37,82 @@
 				"clang-tidy.compilerArgs": [
 					"-std=c++17"
 				],
-				"vsmqtt.brokerProfiles": [
-					{
-						"name": "k3d",
-						"host": "localhost",
-						"port": 31883,
-						"clientId": "vsmqtt_client"
-					},
-					{
-						"name": "local",
-						"host": "localhost",
-						"port": 1883,
-						"clientId": "vsmqtt_client"
-					}
-				],
-				"json.format.keepLines": true,
 				"terminal.integrated.defaultProfile.linux": "zsh",
 				"terminal.integrated.profiles.linux": {
 					"zsh": {
 						"path": "/usr/bin/zsh"
 					}
+				},
+				"vsmqtt.brokerProfiles": [
+					{
+						"name": "mosquitto (local)",
+						"host": "localhost",
+						"port": 1883,
+						"clientId": "vsmqtt_client"
+					},
+					{
+						"name": "mosquitto (k3d)",
+						"host": "localhost",
+						"port": 31883,
+						"clientId": "vsmqtt_client"
+					},
+					{
+						"name": "mosquitto (kanto)",
+						"host": "localhost",
+						"port": 1883,
+						"clientId": "vsmqtt_client"
+					}
+				],
+				"files.associations": {
+					"array": "cpp",
+					"atomic": "cpp",
+					"bit": "cpp",
+					"*.tcc": "cpp",
+					"cctype": "cpp",
+					"chrono": "cpp",
+					"clocale": "cpp",
+					"cmath": "cpp",
+					"compare": "cpp",
+					"concepts": "cpp",
+					"condition_variable": "cpp",
+					"csignal": "cpp",
+					"cstdint": "cpp",
+					"cstdio": "cpp",
+					"cstdlib": "cpp",
+					"cstring": "cpp",
+					"ctime": "cpp",
+					"cwchar": "cpp",
+					"cwctype": "cpp",
+					"deque": "cpp",
+					"list": "cpp",
+					"map": "cpp",
+					"unordered_map": "cpp",
+					"vector": "cpp",
+					"exception": "cpp",
+					"functional": "cpp",
+					"initializer_list": "cpp",
+					"iosfwd": "cpp",
+					"iostream": "cpp",
+					"istream": "cpp",
+					"limits": "cpp",
+					"memory": "cpp",
+					"mutex": "cpp",
+					"new": "cpp",
+					"numbers": "cpp",
+					"ostream": "cpp",
+					"ratio": "cpp",
+					"semaphore": "cpp",
+					"stdexcept": "cpp",
+					"stop_token": "cpp",
+					"streambuf": "cpp",
+					"string": "cpp",
+					"string_view": "cpp",
+					"system_error": "cpp",
+					"thread": "cpp",
+					"tuple": "cpp",
+					"type_traits": "cpp",
+					"typeinfo": "cpp",
+					"utility": "cpp"
 				}
 			},
 			// Add the IDs of extensions you want installed when the container is created.
@@ -66,7 +125,7 @@
 				"bierner.markdown-mermaid",
 				"cschlosser.doxdocgen",
 				"xaver.clang-format",
-				"notskm.clang-tidy",
+				"cs128.cs128-clang-tidy",
 				"matepek.vscode-catch2-test-adapter",
 				"sanaajani.taskrunnercode",
 				"augustocdias.tasks-shell-input"

--- a/setup/src/python/common/devcontainer.json
+++ b/setup/src/python/common/devcontainer.json
@@ -14,22 +14,63 @@
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
-				"python.pythonPath": "/usr/bin/python3",
 				"python.defaultInterpreterPath": "/usr/bin/python3",
+				"python.analysis.typeCheckingMode": "basic",
+				// Strong Type Checker
+				"python.linting.mypyEnabled": true,
+				"mypy.runUsingActiveInterpreter": true,
+				"python.linting.mypyArgs": [],
+				"mypy.targets": [
+					"app"
+				],
+				// Security Linter
+				"python.linting.banditEnabled": true,
+				"python.linting.banditArgs": [
+					"-c setup.cfg"
+				],
 				// Only Flake8 is used as linter and static code analyzer, as faster tool
 				"python.linting.enabled": true,
 				"python.linting.flake8Enabled": true,
+				// Style Checker for Python Docs
+				"python.linting.pydocstyleEnabled": true,
+				"python.analysis.extraPaths": [
+					"./proto",
+					"./src/vehicle_model"
+				],
+				"python.testing.unittestEnabled": false,
+				"python.testing.pytestEnabled": true,
 				// Style Formatter
 				"python.formatting.provider": "black",
-				// Security Linter
-				"python.linting.banditEnabled": true,
-				"python.disableInstallationCheck": true,
+				"vs-kubernetes": {
+					"vscode-kubernetes.kubectl-path.linux": "/usr/bin/kubectl",
+					"vscode-kubernetes.helm-path.linux": "/usr/local/bin/helm"
+				},
 				"terminal.integrated.defaultProfile.linux": "zsh",
 				"terminal.integrated.profiles.linux": {
 					"zsh": {
 						"path": "/usr/bin/zsh"
 					}
-				}
+				},
+				"vsmqtt.brokerProfiles": [
+					{
+						"name": "mosquitto (local)",
+						"host": "localhost",
+						"port": 1883,
+						"clientId": "vsmqtt_client"
+					},
+					{
+						"name": "mosquitto (k3d)",
+						"host": "localhost",
+						"port": 31883,
+						"clientId": "vsmqtt_client"
+					},
+					{
+						"name": "mosquitto (kanto)",
+						"host": "localhost",
+						"port": 1883,
+						"clientId": "vsmqtt_client"
+					}
+				]
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [


### PR DESCRIPTION
Currently we are using the devcontainer.json and the settings.json for definition of settings. This PR moves all the settings to the devcontainer.json, since we already have this enabled for sync with the velocitas cli.

With this we can directly control which settings we want to have.