### PR TITLE
Reduce release binary file size

### DIFF
--- a/build-system/cpp-cmake-conan/src/build.py
+++ b/build-system/cpp-cmake-conan/src/build.py
@@ -91,6 +91,7 @@ def build(
         cxx_flags.append("--coverage")
 
     if build_variant == "release":
+        cxx_flags.append("-s")
         cxx_flags.append("-O3")
     else:
         cxx_flags.append("-O0")


### PR DESCRIPTION
Re-introduces the `-s` compiler flag for stripping symbols from the released binary to reduce app size.