### PR TITLE
Create separate build folder for cross building

### DIFF
--- a/build-system/cpp-cmake-conan/src/build.py
+++ b/build-system/cpp-cmake-conan/src/build.py
@@ -30,7 +30,13 @@ def safe_get_workspace_dir() -> str:
     try:
         return get_workspace_dir()
     except Exception:
-        return "."
+        return os.path.abspath(".")
+
+
+def get_build_folder(build_arch: str, host_arch: str):
+    if host_arch == build_arch:
+        return os.path.join(safe_get_workspace_dir(), "build")
+    return os.path.join(safe_get_workspace_dir(), f"build_linux_{host_arch}")
 
 
 def get_build_tools_path(build_folder_path: str) -> str:
@@ -84,8 +90,6 @@ def build(
     static_build: bool,
     coverage: bool = True,
 ) -> None:
-    build_folder = os.path.join(safe_get_workspace_dir(), "build")
-
     cxx_flags = ["-g"]
     if coverage:
         cxx_flags.append("--coverage")
@@ -96,6 +100,7 @@ def build(
     else:
         cxx_flags.append("-O0")
 
+    build_folder = get_build_folder(build_arch, host_arch)
     os.makedirs(build_folder, exist_ok=True)
 
     xcompile_toolchain_file = ""
@@ -116,7 +121,8 @@ def build(
             f'-DBUILD_TOOLS_PATH:STRING="{get_build_tools_path(build_folder)}"',
             f"-DSTATIC_BUILD:BOOL={'TRUE' if static_build else 'FALSE'}",
             xcompile_toolchain_file,
-            "-S..",
+            "-S",
+            safe_get_workspace_dir(),
             "-B.",
             "-G",
             "Ninja",

--- a/build-system/cpp-cmake-conan/src/install_deps.py
+++ b/build-system/cpp-cmake-conan/src/install_deps.py
@@ -30,7 +30,13 @@ def safe_get_workspace_dir() -> str:
     try:
         return get_workspace_dir()
     except Exception:
-        return "."
+        return os.path.abspath(".")
+
+
+def get_build_folder(build_arch: str, host_arch: str):
+    if host_arch == build_arch:
+        return os.path.join(safe_get_workspace_dir(), "build")
+    return os.path.join(safe_get_workspace_dir(), f"build_linux_{host_arch}")
 
 
 def get_profile_name(arch: str, build_variant: str) -> str:
@@ -71,7 +77,7 @@ def install_deps_via_conan(
         )
     )
 
-    build_folder = os.path.join(safe_get_workspace_dir(), "build")
+    build_folder = get_build_folder(build_arch, host_arch)
     os.makedirs(build_folder, exist_ok=True)
 
     deps_to_build = "missing" if not build_all_deps else "*"
@@ -96,7 +102,7 @@ def install_deps_via_conan(
             profile_build_path,
             "--build",
             deps_to_build,
-            "..",
+            safe_get_workspace_dir(),
         ],
         env=os.environ,
         cwd=build_folder,


### PR DESCRIPTION
Create separate build folder with this "strategy":
* If build and host arch are identical, use folder `build` (reason: No change for local simulation environment required)
* else use folder `build_linux_<arch>`