### PR TITLE
Changing Server Start Output

### DIFF
--- a/grpc-interface-support/data/templates/cpp/ServiceNameServiceServerFactory.cc
+++ b/grpc-interface-support/data/templates/cpp/ServiceNameServiceServerFactory.cc
@@ -16,6 +16,7 @@
 
 #include "${{ service_include_dir }}/${{ service_name_camel_case }}ServiceServerFactory.h"
 #include "sdk/middleware/Middleware.h"
+#include "sdk/Logger.h"
 
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
@@ -38,7 +39,7 @@ std::unique_ptr<grpc::Server> ${{ service_name_camel_case }}ServiceServerFactory
     builder.RegisterService(service.get());
     // Finally assemble the server.
     std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
-    std::cout << "Server listening on " << serviceLocation << std::endl;
+    velocitas::logger().info("Server ${{ package_id }}::${{ service_name }} listening on {}", serviceLocation);
 
     return server;
 }


### PR DESCRIPTION
Tested by

**Sample Program**

```
int main(int argc, char** argv) {
    signal(SIGINT, signal_handler);

    std::cout << "hjdjkfsdsddsd\n";
    auto seatsImpl = std::make_shared<velocitas::SeatsService>();

    auto seatServer = velocitas::SeatsServiceServerFactory::create(
        velocitas::Middleware::getInstance(), seatsImpl);

    std::cout << "hjdjkfs46476dsddsd\n";
```

**Changing velocitas.json to use this one**

```
"packages": {
        "devenv-runtimes": "v4.0.6",
        "devenv-github-workflows": "v6.1.3",
        "devenv-github-templates": "v1.0.5",
        "https://github.com/SoftwareDefinedVehicle/devenv-devcontainer-setup.git": "@erik_cout"
    },
```

**And running it in dev container**

Now shown as INFO

```
vscode ➜ /workspaces/cp--example-1 (main) $ export SDV_SEATS_ADDRESS=127.0.0.1:1234
vscode ➜ /workspaces/cp--example-1 (main) $ build/bin/app                          
hjdjkfsdsddsd
2024-09-10 06:52:38, INFO  : Server listening on 127.0.0.1:1234
hjdjkfs46476dsddsd
```

**After update based on review comments**

```
vscode ➜ /workspaces/cp--example-1 (main) $ export SDV_SEATS_ADDRESS=127.0.0.1:1234
vscode ➜ /workspaces/cp--example-1 (main) $ build/bin/app                          
hjdjkfsdsddsd
2024-09-10 10:43:07, INFO  : Server sdv::edge::comfort::seats::v1::Seats listening on 127.0.0.1:1234
hjdjkfs46476dsddsd
```
