### PR TITLE
Remove chown from onCreateCommand

### DIFF
--- a/setup/src/common/scripts/onCreateCommand.sh
+++ b/setup/src/common/scripts/onCreateCommand.sh
@@ -14,7 +14,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 sudo chmod +x .devcontainer/scripts/*.sh
-sudo chown -R $(whoami) $HOME
 
 .devcontainer/scripts/setup-git.sh
 


### PR DESCRIPTION
The chown command can be removed, because it no longer has any impact. 
The devcontainer is always created as the user "vscode" as defined in .devcontainer.json and / or DOCKERFILE

Tested the following scenarios:
- delete devcontainer (e.g. using colima delete) (before doing everything else)
- recreate devcontainer
- execute "velocitas init -fv"
- add door.proto, add configuration to appmanifest.json and "re-generate gRPC files"
- generate vehicle-model
- start / stop runtime-local 

Tested using the following branch: 
https://github.com/SoftwareDefinedVehicle/vehicle-app-cpp-template/tree/remove_chown_test