### PR TITLE
Provide backward compatibility for setup component

### DIFF
--- a/setup/src/cpp/common/scripts/setup-dependencies.sh
+++ b/setup/src/cpp/common/scripts/setup-dependencies.sh
@@ -46,4 +46,4 @@ fi
 echo "#######################################################"
 echo "### Install Dependencies                            ###"
 echo "#######################################################"
-velocitas exec build-system install 2>&1 | tee -a $HOME/install_dependencies.log
+./install_dependencies.sh 2>&1 | tee -a $HOME/install_dependencies.log


### PR DESCRIPTION
With this PR we could upgrade the C++ SDK to the latest version of devenv-devcontainer-setup without using the build-system which requires further work.