### PR TITLE
don't use python venv for model installation

### DIFF
--- a/vehicle-model-lifecycle/src/generate_model.py
+++ b/vehicle-model-lifecycle/src/generate_model.py
@@ -17,7 +17,6 @@
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import List
 
@@ -88,7 +87,7 @@ def install_model_if_required(language: str, model_path: str) -> None:
         model_path (str): The path where the generated model is stored.
     """
     if language == "python":
-        subprocess.check_call([sys.executable, "-m", "pip", "install", model_path])
+        subprocess.check_call(["pip", "install", model_path])
     elif language == "cpp" and os.path.isfile(os.path.join(model_path, "conanfile.py")):
         export_conan_project(model_path)
     else:

--- a/vehicle-model-lifecycle/src/generate_model.py
+++ b/vehicle-model-lifecycle/src/generate_model.py
@@ -17,6 +17,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import List
 
@@ -87,7 +88,11 @@ def install_model_if_required(language: str, model_path: str) -> None:
         model_path (str): The path where the generated model is stored.
     """
     if language == "python":
-        subprocess.check_call(["pip", "install", model_path])
+        executable = os.path.join(
+            sys.base_prefix, "bin", sys.executable.split(os.sep)[-1]
+        )
+
+        subprocess.check_call([executable, "-m", "pip", "install", model_path])
     elif language == "cpp" and os.path.isfile(os.path.join(model_path, "conanfile.py")):
         export_conan_project(model_path)
     else:


### PR DESCRIPTION
the model should be available in the user site packages and not just in the venv of the package

hence removing the sys.executable pointing to the venv and use the default python installation